### PR TITLE
Fix set event handlers feature

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,7 +2,7 @@ homepage: "www.simoahava.com"
 documentation: "https://www.simoahava.com/custom-templates/qualaroo/"
 versions:
   # Latest version
-  - sha: 3622547f89862a752174f32314ee17dd7c05dd43
+  - sha: efda5ed858ff560fdcace79dfaecabcffba80770
     changeNotes: Add dataLayer integration
   # Older versions
   - sha: df258958dff00c03c87e2d48899a6fd2f2476203

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,9 +2,11 @@ homepage: "www.simoahava.com"
 documentation: "https://www.simoahava.com/custom-templates/qualaroo/"
 versions:
   # Latest version
+  - sha: 3622547f89862a752174f32314ee17dd7c05dd43
+    changeNotes: Add dataLayer integration
+  # Older versions
   - sha: df258958dff00c03c87e2d48899a6fd2f2476203
     changeNotes: Fix set event handlers feature.
-  # Older versions
   - sha: 8d5357c895141f2512afb4ec567a8a0b44cb2a0c
     changeNotes: Update CDN to cl.qualaroo.com
   - sha: 6d63d77bca7672bf05d785f6d9653c6c11a4551a

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,9 +2,11 @@ homepage: "www.simoahava.com"
 documentation: "https://www.simoahava.com/custom-templates/qualaroo/"
 versions:
   # Latest version
+  - sha: df258958dff00c03c87e2d48899a6fd2f2476203
+    changeNotes: Fix set event handlers feature.
+  # Older versions
   - sha: 8d5357c895141f2512afb4ec567a8a0b44cb2a0c
     changeNotes: Update CDN to cl.qualaroo.com
-  # Older versions
   - sha: 6d63d77bca7672bf05d785f6d9653c6c11a4551a
     changeNotes: Add support for setCookieExpireDays.
   - sha: a782a1b048e78ccf72ef3d5c790894c4dfe5d1bb

--- a/template.tpl
+++ b/template.tpl
@@ -61,6 +61,13 @@ ___TEMPLATE_PARAMETERS___
     "type": "CHECKBOX"
   },
   {
+    "simpleValueType": true,
+    "name": "dlIntegration",
+    "checkboxText": "Add dataLayer integration",
+    "type": "CHECKBOX",
+    "help": "Sets event handlers for the show and submit events."
+  },
+  {
     "enablingConditions": [
       {
         "paramName": "gaIntegration",
@@ -322,9 +329,42 @@ const gaId = data.gaTrackingId;
 const kiq = createQueue('_kiq');
 if (data.disableAuto) kiq(['disableAuto']);
 
+const dataLayerPush = createQueue('dataLayer');
+
 if (data.gaIntegration) {
   const ga = createArgumentsQueue('ga', 'ga.q');
   ga('create', data.gaTrackingId);
+}
+
+if (data.dlIntegration) {
+  kiq(['eventHandler', 'show', function(nudge_id, screen_id, survey_name){
+    dataLayerPush({
+      'event': 'survey_display',
+      'survey_provider': 'Qualaroo',
+      'qualaroo': {
+        'question': undefined,
+        'nudge_id': nudge_id,
+        'screen_id': screen_id,
+        'action': 'show',
+        'survey_name': survey_name
+      }
+    });
+  }]);
+
+  kiq(['eventHandler', 'submit', function(answers_array, nudge_id, screen_id, survey_name){
+    dataLayerPush({
+      'event': 'survey_submit',
+      'survey_provider': 'Qualaroo',
+      'qualaroo': {
+        'question': answers_array[0],
+        'nudge_id': nudge_id,
+        'screen_id': screen_id,
+        'action': 'submit',
+        'survey_name': survey_name
+      }
+
+    });
+  }]);
 }
 
 const addEvents = () => {
@@ -464,6 +504,45 @@ ___WEB_PERMISSIONS___
                   {
                     "type": 1,
                     "string": "ga.q"
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": false
+                  }
+                ]
+              },
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "key"
+                  },
+                  {
+                    "type": 1,
+                    "string": "read"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  },
+                  {
+                    "type": 1,
+                    "string": "execute"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "dataLayer"
                   },
                   {
                     "type": 8,

--- a/template.tpl
+++ b/template.tpl
@@ -219,7 +219,7 @@ ___TEMPLATE_PARAMETERS___
             "displayName": "",
             "simpleTableColumns": [
               {
-                "defaultValue": "",
+                "defaultValue": "show",
                 "displayName": "Event handler",
                 "name": "eventHandler",
                 "type": "SELECT",
@@ -267,8 +267,7 @@ ___TEMPLATE_PARAMETERS___
             "newRowButtonText": "Add event handler"
           }
         ],
-        "help": "See \u003ca href\u003d\"https://help.qualaroo.com/hc/en-us/articles/201447336-Using-Event-Handler-Callbacks\"\u003ethis article\u003c/a\u003e for details on what event handlers you can set and what they do.\n\nNote that the callback for each handler \u003cstrong\u003emust\u003c/strong\u003e be a Google Tag Manager variable that returns a valid function.",
-        "defaultValue": "show"
+        "help": "See \u003ca href\u003d\"https://help.qualaroo.com/hc/en-us/articles/201447336-Using-Event-Handler-Callbacks\"\u003ethis article\u003c/a\u003e for details on what event handlers you can set and what they do.\n\nNote that the callback for each handler \u003cstrong\u003emust\u003c/strong\u003e be a Google Tag Manager variable that returns a valid function."
       },
       {
         "type": "CHECKBOX",

--- a/template.tpl
+++ b/template.tpl
@@ -337,7 +337,7 @@ if (data.gaIntegration) {
 }
 
 if (data.dlIntegration) {
-  kiq(['eventHandler', 'show', function(nudge_id, screen_id, survey_name){
+  kiq(['eventHandler', 'show', (nudge_id, screen_id, survey_name) => {
     dataLayerPush({
       'event': 'survey_display',
       'survey_provider': 'Qualaroo',
@@ -351,18 +351,17 @@ if (data.dlIntegration) {
     });
   }]);
 
-  kiq(['eventHandler', 'submit', function(answers_array, nudge_id, screen_id, survey_name){
+  kiq(['eventHandler', 'submit', (answers_array, nudge_id, screen_id, survey_name) => {
     dataLayerPush({
       'event': 'survey_submit',
       'survey_provider': 'Qualaroo',
       'qualaroo': {
-        'question': answers_array[0],
+        'question': answers_array && answers_array.length ? answers_array[0] : undefined,
         'nudge_id': nudge_id,
         'screen_id': screen_id,
         'action': 'submit',
         'survey_name': survey_name
       }
-
     });
   }]);
 }


### PR DESCRIPTION
The event handlers checkbox had a default value of "show" which prevented opening the table that is used to set event handlers. I removed the default value and instead configured the default value for event in the table entries to be "show".